### PR TITLE
improve asyncchannel usage and thread safety guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,14 @@ Key implementation details:
 
 - Copies: In `refc`, items are deep-copied by the underlying `Channel` while
   holding a lock. Keep messages small or pass handles to off-channel buffers.
-- open/close: open allocates signaling resources (can fail), close must be
-  called once the channel is drained and no tasks are waiting.
+- open/close: open allocates signaling resources (can fail). close rejects new
+  operations, wakes blocked receivers and waits for in-flight send/receive
+  operations to leave the shared state before releasing resources.
+- lifecycle: `close` on a channel that was never opened is a no-op. `open` is
+  one-shot: double-open is rejected, and reopening a closed channel is also
+  rejected.
+- misuse after close: `sendSync` and `recv` raise `AssertionDefect` if called on
+  a channel that is not open anymore.
 - Chronos-only wakeups: `AsyncChannel` can wake `chronos`-managed threads/tasks.
   It cannot wake non-`chronos` threads — use plain `Channel` for that direction.
 - GC compatibility: the channel works with `refc` and `orc` but your payload may

--- a/asyncchannels.nim
+++ b/asyncchannels.nim
@@ -1,10 +1,20 @@
 {.push raises: [], gcsafe.}
 
-import std/typetraits, chronos, chronos/threadsync, results
+import std/typetraits, std/atomics, std/os, chronos, chronos/threadsync, results
 
 export chronos, threadsync, results
 
 const asyncchannelsHints {.booldefine.} = true
+
+# Packed state layout: bit 0 means "open", bit 1 means "closing", and the
+# remaining high bits store the number of in-flight send/recv operations.
+# Each active operation adds/subtracts `asyncChannelRefUnit`, leaving the flag
+# bits untouched while `close` waits for the count to drain to zero.
+const
+  asyncChannelOpenBit = 1'u
+  asyncChannelClosingBit = 2'u
+  asyncChannelRefShift = 2
+  asyncChannelRefUnit = 1'u shl asyncChannelRefShift
 
 type AsyncChannel*[TMsg] = object
   ## Async, unbounded MPMC channel suitable for usage with chronos' `async`
@@ -13,8 +23,9 @@ type AsyncChannel*[TMsg] = object
   ##
   ## Channel lifetime is controlled by `open` and `close` - before `close` is
   ## used, the caller is responsible for making sure that all work posted to
-  ## the channel has been drained and that no threads are waiting for work, or
-  ## memory leaks and crashes may happen.
+  ## the channel has been drained if it matters. Once `close` starts, new
+  ## operations are rejected and the call waits for in-flight `recv` and
+  ## `sendSync` operations to leave the shared state before freeing resources.
   ##
   ## Performance-wise, the channel is suitable for use cases where tasks are:
   ##
@@ -68,6 +79,28 @@ type AsyncChannel*[TMsg] = object
     #      for some reason, `Channel` holds a lock while performing the copy
 
   sig: ThreadSignalPtr
+  state: Atomic[uint]
+
+template activeOps(state: uint): uint =
+  state shr asyncChannelRefShift
+
+proc misuse(op: static string) {.noreturn, noinline.} =
+  raiseAssert "AsyncChannel." & op & " on a channel that is not open"
+
+proc beginOp[T](tc: ptr AsyncChannel[T]): bool =
+  while true:
+    var state = tc.state.load(moAcquire)
+
+    if (state and asyncChannelOpenBit) == 0 or
+        (state and asyncChannelClosingBit) != 0:
+      return false
+
+    let desired = state + asyncChannelRefUnit
+    if tc.state.compareExchange(state, desired, moAcquireRelease, moAcquire):
+      return true
+
+proc endOp[T](tc: ptr AsyncChannel[T]) {.inline.} =
+  discard tc.state.fetchSub(asyncChannelRefUnit, moAcquireRelease)
 
 # TODO https://github.com/nim-lang/Nim/pull/25318
 template tryRecv2*(c: var Channel): untyped =
@@ -81,21 +114,42 @@ template send2*(c: var Channel, msg: auto) =
 proc open*(tc: var AsyncChannel): Result[void, string] =
   ## Prepare the channel for writing - open can fail if therer are not enough
   ## system resources (file descriptors) for the signalling mechanism.
+  if tc.state.load(moAcquire) != 0:
+    return err("AsyncChannel.open on a channel that is already open or closed")
+
   tc.sig = ?ThreadSignalPtr.new()
   # It should not matter that the channel is created in shared memory (since it
   # does not interact with the GC at all) but just to be safe, let's do like the
   # documentation suggests and allocate it like so.
   tc.chan = createShared(typeof(tc.chan[]))
   tc.chan[].open(0)
+  tc.state.store(asyncChannelOpenBit, moRelease)
 
   ok()
 
 proc close*(tc: var AsyncChannel) =
-  ## Release the resources used by the chanel - before calling, ensure that no
-  ## threads are waiting to send or receive data and that all related futures
-  ## have are finished.
-  if tc.sig.isNil:
-    return
+  ## Release the resources used by the chanel.
+  ##
+  ## Once `close` starts, new operations are rejected and blocked receivers are
+  ## woken up until all in-flight operations have left the shared state.
+  while true:
+    var state = tc.state.load(moAcquire)
+
+    if (state and asyncChannelOpenBit) == 0 or
+        (state and asyncChannelClosingBit) != 0:
+      return
+
+    let desired = state or asyncChannelClosingBit
+    if tc.state.compareExchange(state, desired, moAcquireRelease, moAcquire):
+      break
+
+  while true:
+    discard tc.sig.fireSync()
+
+    if tc.state.load(moAcquire).activeOps == 0:
+      break
+
+    sleep(1)
 
   discard tc.sig.close()
   reset tc.sig
@@ -104,6 +158,7 @@ proc close*(tc: var AsyncChannel) =
   tc.chan.deallocShared()
 
   reset tc.chan
+  tc.state.store(asyncChannelClosingBit, moRelease)
 
 template deepCopyHint(T: typedesc) =
   when asyncchannelsHints and (not defined(gcDestructors)) and
@@ -120,12 +175,20 @@ proc recv*[T](
   ##
   ## Operation may be cancelled.
   ##
-  ## Calling this function  on a channel that has not been opened or has already
-  ## been closed is undefined behavior and may lead to panics or blocked threads.
+  ## Calling this function on a channel that has not been opened yet or that is
+  ## closing raises an assertion defect.
 
   deepCopyHint(T)
 
+  if not tc.beginOp():
+    misuse("recv")
+  defer:
+    tc.endOp()
+
   while true:
+    if (tc.state.load(moAcquire) and asyncChannelClosingBit) != 0:
+      misuse("recv")
+
     let (dataAvailable, msg) = tc.chan[].tryRecv2()
 
     if dataAvailable:
@@ -146,6 +209,8 @@ proc recv*[T](
     try:
       await tc.sig.wait()
     except AsyncError as exc:
+      if (tc.state.load(moAcquire) and asyncChannelClosingBit) != 0:
+        misuse("recv")
       raiseAssert exc.msg
 
 proc sendSync*[T, U](tc: var AsyncChannel[T], msg: sink U) =
@@ -154,11 +219,17 @@ proc sendSync*[T, U](tc: var AsyncChannel[T], msg: sink U) =
   ## process them - the limit is OS-dependent due to the cross-thread signalling
   ## mechanism used.
   ##
-  ## Calling this function  on a channel that has not been opened or has already
-  ## been closed is undefined behavior and may lead to panics or blocked threads.
+  ## Calling this function on a channel that has not been opened yet or that is
+  ## closing raises an assertion defect.
   ##
   ## TODO https://github.com/status-im/nim-chronos/issues/604
   deepCopyHint(T)
+
+  if not (addr tc).beginOp():
+    misuse("sendSync")
+  defer:
+    (addr tc).endOp()
+
   tc.chan[].send2(move(msg))
   # Reader will fire in case we need another notification
   discard tc.sig.fireSync()

--- a/asyncchannels.nim
+++ b/asyncchannels.nim
@@ -91,8 +91,7 @@ proc beginOp[T](tc: ptr AsyncChannel[T]): bool =
   while true:
     var state = tc.state.load(moAcquire)
 
-    if (state and asyncChannelOpenBit) == 0 or
-        (state and asyncChannelClosingBit) != 0:
+    if (state and asyncChannelOpenBit) == 0 or (state and asyncChannelClosingBit) != 0:
       return false
 
     let desired = state + asyncChannelRefUnit
@@ -135,8 +134,7 @@ proc close*(tc: var AsyncChannel) =
   while true:
     var state = tc.state.load(moAcquire)
 
-    if (state and asyncChannelOpenBit) == 0 or
-        (state and asyncChannelClosingBit) != 0:
+    if (state and asyncChannelOpenBit) == 0 or (state and asyncChannelClosingBit) != 0:
       return
 
     let desired = state or asyncChannelClosingBit

--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,4 @@
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
+  include "nimble.paths"
+# end Nimble config

--- a/tests/test_asyncchannels.nim
+++ b/tests/test_asyncchannels.nim
@@ -86,3 +86,195 @@ suite "AsyncChannels":
 
     check:
       sump == sumc
+
+  test "double open rejected":
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+
+    let res = chan.open()
+
+    check:
+      res.isErr()
+
+    chan.close()
+
+  test "close before open is no-op":
+    var chan: AsyncChannel[int]
+
+    chan.close()
+
+    check:
+      chan.open().isOk()
+
+    chan.close()
+
+  test "reopen after close rejected":
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+    chan.close()
+
+    let res = chan.open()
+
+    check:
+      res.isErr()
+
+  test "send after close asserts":
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+    chan.close()
+
+    expect AssertionDefect:
+      chan.sendSync(123)
+
+  test "recv after close asserts":
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+    chan.close()
+
+    expect AssertionDefect:
+      discard waitFor (addr chan).recv()
+
+  test "blocked recv wakes during close":
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+
+    proc closer(p: ptr AsyncChannel[int]) {.thread.} =
+      sleep(50)
+      p[].close()
+
+    var closingThread: Thread[ptr AsyncChannel[int]]
+    createThread(closingThread, closer, addr chan)
+
+    expect AssertionDefect:
+      discard waitFor (addr chan).recv()
+
+    closingThread.joinThread()
+
+  test "stress repeated blocked recv close race":
+    for _ in 0 ..< 200:
+      var chan: AsyncChannel[int]
+      chan.open().expect("can open channel")
+
+      proc closer(p: ptr AsyncChannel[int]) {.thread.} =
+        sleep(1)
+        p[].close()
+
+      var closingThread: Thread[ptr AsyncChannel[int]]
+      createThread(closingThread, closer, addr chan)
+
+      expect AssertionDefect:
+        discard waitFor (addr chan).recv()
+
+      closingThread.joinThread()
+
+  test "stress many blocked receivers wake during close":
+    const waiters = 16
+
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+
+    var awakened: Atomic[int]
+    var consumers = newSeq[Thread[(ptr AsyncChannel[int], ptr Atomic[int])]](waiters)
+
+    proc cons(p: (ptr AsyncChannel[int], ptr Atomic[int])) {.thread.} =
+      try:
+        discard waitFor p[0].recv()
+        doAssert false, "recv unexpectedly succeeded"
+      except AssertionDefect:
+        p[1][].atomicInc()
+
+    for consumer in consumers.mitems():
+      createThread(consumer, cons, (addr chan, addr awakened))
+
+    sleep(20)
+    chan.close()
+
+    for consumer in consumers.mitems():
+      consumer.joinThread()
+
+    check:
+      awakened.load() == waiters
+
+  test "stress many concurrent closers":
+    const closers = 16
+
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+
+    var awakened: Atomic[int]
+    var recvThread: Thread[(ptr AsyncChannel[int], ptr Atomic[int])]
+    var closingThreads = newSeq[Thread[ptr AsyncChannel[int]]](closers)
+
+    proc blockedRecv(p: (ptr AsyncChannel[int], ptr Atomic[int])) {.thread.} =
+      try:
+        discard waitFor p[0].recv()
+        doAssert false, "recv unexpectedly succeeded"
+      except AssertionDefect:
+        p[1][].atomicInc()
+
+    proc doClose(p: ptr AsyncChannel[int]) {.thread.} =
+      p[].close()
+
+    createThread(recvThread, blockedRecv, (addr chan, addr awakened))
+
+    sleep(20)
+
+    for closingThread in closingThreads.mitems():
+      createThread(closingThread, doClose, addr chan)
+
+    for closingThread in closingThreads.mitems():
+      closingThread.joinThread()
+
+    recvThread.joinThread()
+
+    check:
+      awakened.load() == 1
+
+  test "stress mixed send recv close":
+    const producers = 8
+    const consumers = 8
+
+    var chan: AsyncChannel[int]
+    chan.open().expect("can open channel")
+
+    var sendsOk, sendsClosed, recvsOk, recvsClosed: Atomic[int]
+    var producerThreads = newSeq[Thread[(ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])]](producers)
+    var consumerThreads = newSeq[Thread[(ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])]](consumers)
+
+    proc prod(p: (ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])) {.thread.} =
+      for i in 0 ..< 5000:
+        try:
+          p[0][].sendSync(i)
+          p[1][].atomicInc()
+        except AssertionDefect:
+          p[2][].atomicInc()
+          return
+
+    proc cons(p: (ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])) {.thread.} =
+      while true:
+        try:
+          discard waitFor p[0].recv()
+          p[1][].atomicInc()
+        except AssertionDefect:
+          p[2][].atomicInc()
+          return
+
+    for producer in producerThreads.mitems():
+      createThread(producer, prod, (addr chan, addr sendsOk, addr sendsClosed))
+
+    for consumer in consumerThreads.mitems():
+      createThread(consumer, cons, (addr chan, addr recvsOk, addr recvsClosed))
+
+    sleep(20)
+    chan.close()
+
+    for producer in producerThreads.mitems():
+      producer.joinThread()
+
+    for consumer in consumerThreads.mitems():
+      consumer.joinThread()
+
+    check:
+      sendsOk.load() + sendsClosed.load() > 0
+      recvsOk.load() + recvsClosed.load() > 0
+      recvsClosed.load() == consumers

--- a/tests/test_asyncchannels.nim
+++ b/tests/test_asyncchannels.nim
@@ -238,8 +238,12 @@ suite "AsyncChannels":
     chan.open().expect("can open channel")
 
     var sendsOk, sendsClosed, recvsOk, recvsClosed: Atomic[int]
-    var producerThreads = newSeq[Thread[(ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])]](producers)
-    var consumerThreads = newSeq[Thread[(ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])]](consumers)
+    var producerThreads = newSeq[
+      Thread[(ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])]
+    ](producers)
+    var consumerThreads = newSeq[
+      Thread[(ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])]
+    ](consumers)
 
     proc prod(p: (ptr AsyncChannel[int], ptr Atomic[int], ptr Atomic[int])) {.thread.} =
       for i in 0 ..< 5000:


### PR DESCRIPTION
GM/GE @arnetheduck !

As I started my multi-thread brokers implementation based on AsyncChannel thread IPC I faced with some use cases that shown that without thread safety guaranties in AsyncChannels the only option I have, in order to avoid possible crash scenarios, is to intentionally leak the channel.

With this PR I try to solve such issues as using the channel after close (which can happen also in race conditions), or such UB's like use without open.

Extended tests with edge cases and stress test conditions.

I hope you will find it useful and valuable add-on.